### PR TITLE
Fix whitelisted ubuntu precise package name

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -6188,8 +6188,7 @@ libpqxx-3.1
 libpqxx-3.1-dbg
 libpqxx3-dev
 libpqxx3-doc
-libprocps4
-libprocps4-dev
+libproc-dev
 libproj-dev
 libproj-dev:i386
 libproj-java


### PR DESCRIPTION
It seems that the automatic process has created pull request with a wrong package name for whitelisting. There is no libprocps4-dev in the ubuntu precise repository.

Statement based on:
http://packages.ubuntu.com/search?suite=precise&section=all&arch=any&keywords=libproc&searchon=names

NOTE:
I've read the info about not accepting pull requests for this repo. Anyway, I took the liberty to create this one, because the procps package is already whitelisted, and the dev counterpart (the fixed one) contains only include files, so it should bring no harm, I hope.
