### PR TITLE
Add bin86 & bcc to ubuntu-precise

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -240,7 +240,9 @@ bash-completion
 bash:i386
 bc
 bc:i386
+bcc
 biblatex
+bin86
 binary_package.name
 binfmt-support
 binfmt-support:i386


### PR DESCRIPTION
Add bin86 & bcc to ubuntu-precise; resolves travis-ci/apt-package-whitelist#2320

Packages: bin86 bcc

This is to avoid the issue of elks-libc, which I am not looking to be whitelisted.
