### PR TITLE
Pull request for dbus in precise

### DIFF
--- a/ubuntu-precise
+++ b/ubuntu-precise
@@ -675,6 +675,8 @@ db-util:i386
 dblatex
 dbtoepub
 dbus
+dbus-1-dbg
+dbus-1-doc
 dbus-x11
 dbus-x11:i386
 dbus:i386
@@ -5242,6 +5244,7 @@ libdbi1
 libdbi1-dbg
 libdbus-1-3
 libdbus-1-3:i386
+libdbus-1-dev
 libdbus-glib-1-2
 libdbus-glib-1-2-dbg
 libdbus-glib-1-2:i386


### PR DESCRIPTION
Resolves travis-ci/apt-package-safelist#66.


***NOTE***

setuid/seteuid/setgid bits were found. Be sure to check the build result.

Add packages: dbus dbus-x11 libdbus-1-3 dbus-1-doc libdbus-1-dev dbus-1-dbg

See http://travis-ci.org/travis-ci/apt-whitelist-checker/builds/439974657.