### PR TITLE
Remove non-existant `openmpi` pkg from trusty package whitelist

### DIFF
--- a/ubuntu-trusty
+++ b/ubuntu-trusty
@@ -11149,7 +11149,6 @@ openjpip-dec-server
 openjpip-server
 openjpip-viewer
 openjpip-viewer-xerces
-openmpi
 openmpi-bin
 openmpi-bin:i386
 openmpi-checkpoint


### PR DESCRIPTION
No such `openmpi` package exists in Ubuntu Trusty: https://packages.ubuntu.com/search?suite=trusty&keywords=openmpi
Fixes #2030 

This caused me a ton of confusion since it is listed in the whitelist.